### PR TITLE
[feature] SC-166737/improve app proxy security by restricting where token replacements can go

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -77,9 +77,56 @@
   "proxy": {
     "whitelist": [
       {
-        "url": "https://.*",
+        "url": "https://dev.azure.com/.*",
         "methods": ["GET", "POST", "PUT", "PATCH"],
-        "timeout": 10
+        "timeout": 10,
+        "settingsInjection": {
+          "account_name_pat_token": {
+            "header": ["Authorization"]
+          },
+          "global_settings": {
+            "header": ["Authorization"]
+          }
+        }
+      },
+      {
+        "url": "https://vssps.dev.azure.com/.*",
+        "methods": ["GET", "POST", "PUT", "PATCH"],
+        "timeout": 10,
+        "settingsInjection": {
+          "account_name_pat_token": {
+            "header": ["Authorization"]
+          },
+          "global_settings": {
+            "header": ["Authorization"]
+          }
+        }
+      },
+      {
+        "url": "https://app.vssps.visualstudio.com/oauth2/.*",
+        "methods": ["GET", "POST", "PUT", "PATCH"],
+        "timeout": 10,
+        "settingsInjection": {
+          "client_secret": {
+            "body": ["client_assertion"]
+          },
+          "global_settings": {
+            "body": ["assertion"]
+          }
+        }
+      },
+      {
+        "url": "https://__instance_url__/.*",
+        "methods": ["GET", "POST", "PUT", "PATCH"],
+        "timeout": 10,
+        "settingsInjection": {
+          "account_name_pat_token": {
+            "header": ["Authorization"]
+          },
+          "global_settings": {
+            "header": ["Authorization"]
+          }
+        }
       }
     ]
   }


### PR DESCRIPTION
This pull request updates the proxy configuration in `manifest.json` to improve security and support for Azure DevOps endpoints. The changes restrict allowed proxy URLs, add new endpoint support, and introduce settings injection for authorization and secrets.

Proxy configuration updates:

* Restricted the proxy whitelist to specific Azure DevOps endpoints (`https://dev.azure.com/.*`, `https://vssps.dev.azure.com/.*`, `https://app.vssps.visualstudio.com/oauth2/.*`, and `https://__instance_url__/.*`) to enhance security.
* Added `settingsInjection` for each endpoint, allowing secure injection of authorization tokens and secrets into request headers or bodies.
* Enabled support for OAuth2 authentication by injecting client secrets and assertions into the body for the Visual Studio OAuth2 endpoint.